### PR TITLE
refactor: switch to NarrowedContext

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
 		"telegram-format": "^2.0.0"
 	},
 	"peerDependencies": {
-		"telegraf": "^4.1.0"
+		"telegraf": "^4.3.0"
 	},
 	"devDependencies": {
 		"@sindresorhus/tsconfig": "^0.9.0",
@@ -38,7 +38,7 @@
 		"ava": "^3.0.0",
 		"del-cli": "^3.0.0",
 		"nyc": "^15.0.0",
-		"telegraf": "4.2.1",
+		"telegraf": "4.3.0",
 		"typegram": "^3.0.2",
 		"typescript": "^4.1.2",
 		"xo": "^0.38.1"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
 		"telegram-format": "^2.0.0"
 	},
 	"peerDependencies": {
-		"telegraf": "^4.0.0"
+		"telegraf": "^4.1.0"
 	},
 	"devDependencies": {
 		"@sindresorhus/tsconfig": "^0.9.0",
@@ -38,7 +38,7 @@
 		"ava": "^3.0.0",
 		"del-cli": "^3.0.0",
 		"nyc": "^15.0.0",
-		"telegraf": "^4.0.0",
+		"telegraf": "4.2.1",
 		"typegram": "^3.0.2",
 		"typescript": "^4.1.2",
 		"xo": "^0.38.1"

--- a/source/identifier.ts
+++ b/source/identifier.ts
@@ -1,14 +1,17 @@
-import {Context as TelegrafContext} from 'telegraf'
+import {Context as TelegrafContext, NarrowedContext} from 'telegraf'
 import {markdown, markdownv2, html} from 'telegram-format'
-import {MessageEntity, Message} from 'typegram'
+import {MessageEntity, Message, Update} from 'typegram'
 
 const URL_TEXT = '\u200C'
 const BASE_URL = 'http://t.me/#'
 const URL_SEPERATOR = '#'
 
-// TODO: refactor when GuardedContext (or whatever its named) is out (see https://github.com/telegraf/telegraf/discussions/1284)
+// ReplyMessage from typegram is not exported
 type ReplyToMessage = NonNullable<Message.CommonMessage['reply_to_message']>
-export type ReplyToMessageContext<Context extends TelegrafContext> = Context & {message: Message.CommonMessage & {reply_to_message: ReplyToMessage}}
+
+type MessageUpdateContext<Context extends TelegrafContext> = NarrowedContext<Context, Update.MessageUpdate>
+export type ReplyToMessageContext<Context extends TelegrafContext> = MessageUpdateContext<Context> & {message: MessageUpdateContext<Context>['message'] & {reply_to_message: ReplyToMessage}}
+
 export type UrlMessageEntity = Readonly<MessageEntity.TextLinkMessageEntity>
 
 export function isContextReplyToMessage<Context extends TelegrafContext>(context: Context): context is ReplyToMessageContext<Context> {


### PR DESCRIPTION
Telegraf does ship with `NarrowedContext` with 4.1 which should improve the typings.

The typescript compiler does not seem to be happy about this. Any ideas how to do that better @wojpawlik ?
