### PR TITLE
Usage with grammY and telegraf

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,9 +30,6 @@
 	"dependencies": {
 		"telegram-format": "^2.0.0"
 	},
-	"peerDependencies": {
-		"telegraf": "^4.0.0"
-	},
 	"devDependencies": {
 		"@sindresorhus/tsconfig": "^1.0.1",
 		"@types/node": "^15.0.1",
@@ -40,7 +37,6 @@
 		"del-cli": "^4.0.0",
 		"nyc": "^15.0.0",
 		"telegraf": "^4.0.0",
-		"typegram": "^3.0.2",
 		"typescript": "^4.2.3",
 		"xo": "^0.40.0"
 	},

--- a/source/index.ts
+++ b/source/index.ts
@@ -1,19 +1,18 @@
-import {Context as TelegrafContext, MiddlewareFn} from 'telegraf'
-import {Message} from 'typegram'
 
-import {suffixHTML, suffixMarkdown, suffixMarkdownV2, isContextReplyToMessage, isReplyToQuestion, ReplyToMessageContext, getAdditionalState} from './identifier'
+import {MiddlewareFn, ContextWithReply, ContextWithMessage} from './types.js'
+import {suffixHTML, suffixMarkdown, suffixMarkdownV2, isReplyToQuestion, getAdditionalState} from './identifier'
 
 type ConstOrPromise<T> = T | Promise<T>
 
-export default class TelegrafStatelessQuestion<Context extends TelegrafContext> {
+export default class TelegrafStatelessQuestion<Context extends ContextWithMessage> {
 	constructor(
 		public readonly uniqueIdentifier: string,
-		private readonly answer: (context: ReplyToMessageContext<Context>, additionalState: string) => ConstOrPromise<void>
+		private readonly answer: (context: Context, additionalState: string) => ConstOrPromise<void>
 	) {}
 
 	middleware(): MiddlewareFn<Context> {
 		return async (context, next) => {
-			if (isContextReplyToMessage(context) && isReplyToQuestion(context, this.uniqueIdentifier)) {
+			if (isReplyToQuestion(context, this.uniqueIdentifier)) {
 				const additionalState = getAdditionalState(context, this.uniqueIdentifier)
 				return this.answer(context, additionalState)
 			}
@@ -34,17 +33,17 @@ export default class TelegrafStatelessQuestion<Context extends TelegrafContext> 
 		return suffixMarkdownV2(this.uniqueIdentifier, additionalState)
 	}
 
-	async replyWithHTML(context: TelegrafContext, text: string, additionalState?: string): Promise<Message> {
+	async replyWithHTML<Message>(context: ContextWithReply<Message>, text: string, additionalState?: string): Promise<Message> {
 		const textResult = text + this.messageSuffixHTML(additionalState)
 		return context.reply(textResult, {reply_markup: {force_reply: true}, parse_mode: 'HTML'})
 	}
 
-	async replyWithMarkdown(context: TelegrafContext, text: string, additionalState?: string): Promise<Message> {
+	async replyWithMarkdown<Message>(context: ContextWithReply<Message>, text: string, additionalState?: string): Promise<Message> {
 		const textResult = text + this.messageSuffixMarkdown(additionalState)
 		return context.reply(textResult, {reply_markup: {force_reply: true}, parse_mode: 'Markdown'})
 	}
 
-	async replyWithMarkdownV2(context: TelegrafContext, text: string, additionalState?: string): Promise<Message> {
+	async replyWithMarkdownV2<Message>(context: ContextWithReply<Message>, text: string, additionalState?: string): Promise<Message> {
 		const textResult = text + this.messageSuffixMarkdownV2(additionalState)
 		return context.reply(textResult, {reply_markup: {force_reply: true}, parse_mode: 'MarkdownV2'})
 	}

--- a/source/types.ts
+++ b/source/types.ts
@@ -1,0 +1,53 @@
+interface Extra {
+	readonly parse_mode: 'HTML' | 'Markdown' | 'MarkdownV2';
+	readonly reply_markup: {
+		readonly force_reply: true;
+	};
+}
+
+export interface UrlMessageEntity {
+	readonly type: 'text_link';
+	readonly url: string;
+}
+
+export interface ReplyToMessage {
+	readonly entities?: unknown[];
+	readonly caption_entities?: unknown[];
+}
+
+export interface MessageWithReplyTo {
+	readonly reply_to_message: ReplyToMessage;
+}
+
+export interface ContextInReplyTo {
+	readonly message: MessageWithReplyTo;
+}
+
+export interface ContextWithMessage {
+	readonly message: unknown;
+}
+
+export interface ContextWithReply<Message> {
+	readonly reply: (text: string, extra: Extra) => Promise<Message>;
+}
+
+export type MiddlewareFn<Context> = (ctx: Context, next: () => Promise<void>) => Promise<void>
+
+export function isUrlMessageEntity(entity: unknown): entity is UrlMessageEntity {
+	return typeof entity === 'object' && entity !== null &&
+		hasProperty(entity, 'type') && hasProperty(entity, 'url') &&
+		entity.type === 'text_link' && typeof entity.url === 'string'
+}
+
+export function hasReplyToMessage(message: unknown): message is MessageWithReplyTo {
+	if (typeof message === 'object' && message !== null && hasProperty(message, 'reply_to_message')) {
+		const r = message.reply_to_message
+		return typeof r === 'object' && r !== null
+	}
+
+	return false
+}
+
+function hasProperty<P extends PropertyKey>(object: unknown, prop: P): object is Record<P, unknown> {
+	return typeof object === 'object' && object !== null && prop in object
+}

--- a/test/test.ts
+++ b/test/test.ts
@@ -1,5 +1,5 @@
 import test from 'ava'
-import {Telegraf} from 'telegraf'
+import {Telegraf, Context as TelegrafContext} from 'telegraf'
 
 import {suffixHTML, suffixMarkdown, suffixMarkdownV2} from '../source/identifier'
 import TelegrafStatelessQuestion from '../source'
@@ -309,9 +309,13 @@ test('ignores message replying to another question', async t => {
 test('correctly works with text message', async t => {
 	const bot = new Telegraf('')
 	bot.botInfo = {} as any
-	const question = new TelegrafStatelessQuestion('unicorns', ctx => {
+	const question = new TelegrafStatelessQuestion<TelegrafContext>('unicorns', ctx => {
+		if (!ctx.message || !('reply_to_message' in ctx.message)) {
+			throw new Error('incorrect type')
+		}
+
 		t.is(ctx.message.message_id, 42)
-		t.is(ctx.message.reply_to_message.message_id, 43)
+		t.is(ctx.message.reply_to_message?.message_id, 43)
 	})
 	bot.use(question.middleware())
 	bot.use(() => {
@@ -346,9 +350,13 @@ test('correctly works with text message', async t => {
 test('correctly works with text message with additional state', async t => {
 	const bot = new Telegraf('')
 	bot.botInfo = {} as any
-	const question = new TelegrafStatelessQuestion('unicorns', (ctx, additionalState) => {
+	const question = new TelegrafStatelessQuestion<TelegrafContext>('unicorns', (ctx, additionalState) => {
+		if (!ctx.message || !('reply_to_message' in ctx.message)) {
+			throw new Error('incorrect type')
+		}
+
 		t.is(ctx.message.message_id, 42)
-		t.is(ctx.message.reply_to_message.message_id, 43)
+		t.is(ctx.message.reply_to_message?.message_id, 43)
 		t.is(additionalState, 'explode')
 	})
 	bot.use(question.middleware())
@@ -384,9 +392,13 @@ test('correctly works with text message with additional state', async t => {
 test('additional state url encoding is removed before passed to function', async t => {
 	const bot = new Telegraf('')
 	bot.botInfo = {} as any
-	const question = new TelegrafStatelessQuestion('unicorns', (ctx, additionalState) => {
+	const question = new TelegrafStatelessQuestion<TelegrafContext>('unicorns', (ctx, additionalState) => {
+		if (!ctx.message || !('reply_to_message' in ctx.message)) {
+			throw new Error('incorrect type')
+		}
+
 		t.is(ctx.message.message_id, 42)
-		t.is(ctx.message.reply_to_message.message_id, 43)
+		t.is(ctx.message.reply_to_message?.message_id, 43)
 		t.is(additionalState, 'foo bar')
 	})
 	bot.use(question.middleware())
@@ -422,9 +434,13 @@ test('additional state url encoding is removed before passed to function', async
 test('correctly works with media message', async t => {
 	const bot = new Telegraf('')
 	bot.botInfo = {} as any
-	const question = new TelegrafStatelessQuestion('unicorns', ctx => {
+	const question = new TelegrafStatelessQuestion<TelegrafContext>('unicorns', ctx => {
+		if (!ctx.message || !('reply_to_message' in ctx.message)) {
+			throw new Error('incorrect type')
+		}
+
 		t.is(ctx.message.message_id, 42)
-		t.is(ctx.message.reply_to_message.message_id, 43)
+		t.is(ctx.message.reply_to_message?.message_id, 43)
 	})
 	bot.use(question.middleware())
 	bot.use(() => {


### PR DESCRIPTION
Remove (peer) dependency to telegraf and assume types within this package. TypeScript will then ensure Telegraf / grammY is working with this package.

Downside (=breaking change): less good knowledge about ctx.
This can be seen in the changes to the tests.